### PR TITLE
Add some functions to list available and reserved glasses

### DIFF
--- a/extension/T5Integration/Glasses.h
+++ b/extension/T5Integration/Glasses.h
@@ -80,6 +80,7 @@ class Glasses
     const std::string get_id();    
     const std::string get_name();
     bool is_connected();
+    bool is_available();
     bool is_tracking();
     
    bool allocate_handle(T5_Context context);
@@ -189,6 +190,11 @@ inline const std::string Glasses::get_name() {
 inline bool Glasses::is_connected() 
 { 
     return _state.is_current(GlassesState::CONNECTED); 
+}
+
+inline bool Glasses::is_available() 
+{ 
+    return !(_state.is_current(GlassesState::SUSTAIN_CONNECTION) || _state.is_current(GlassesState::UNAVAILABLE)); 
 }
 
 inline bool Glasses::is_tracking() 

--- a/extension/src/TiltFiveXRInterface.cpp
+++ b/extension/src/TiltFiveXRInterface.cpp
@@ -18,6 +18,8 @@ void TiltFiveXRInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("start_display", "glasses_id", "viewport", "xr_origin"), &TiltFiveXRInterface::start_display);
 	ClassDB::bind_method(D_METHOD("stop_display", "glasses_id"), &TiltFiveXRInterface::stop_display);
 	ClassDB::bind_method(D_METHOD("release_glasses", "glasses_id"), &TiltFiveXRInterface::release_glasses);
+	ClassDB::bind_method(D_METHOD("get_available_glasses_ids"), &TiltFiveXRInterface::get_available_glasses_ids);
+	ClassDB::bind_method(D_METHOD("get_reserved_glasses_ids"), &TiltFiveXRInterface::get_reserved_glasses_ids);
 
 	// Properties.
 
@@ -173,6 +175,30 @@ void TiltFiveXRInterface::release_glasses(const StringName glasses_id) {
 	ERR_FAIL_COND_MSG(!entry, "Glasses id was not found");
 	_stop_display(*entry);
 	t5_service->release_glasses(entry->idx);
+}
+
+PackedStringArray TiltFiveXRInterface::get_available_glasses_ids() {
+    if(!t5_service) return PackedStringArray();
+	
+	PackedStringArray available_list;
+	for(int i = 0; i < t5_service->get_glasses_count(); i++) {
+		auto glasses = t5_service->get_glasses(i);
+		if(glasses->is_available())
+			available_list.append(glasses->get_id().c_str());
+	}
+	return available_list;
+}
+
+PackedStringArray TiltFiveXRInterface::get_reserved_glasses_ids() {
+    if(!t5_service) return PackedStringArray();
+	
+	PackedStringArray reserved_list;
+	for(int i = 0; i < t5_service->get_glasses_count(); i++) {
+		auto glasses = t5_service->get_glasses(i);
+		if(glasses->is_in_use())
+			reserved_list.append(glasses->get_id().c_str());
+	}
+	return reserved_list;
 }
 
 StringName TiltFiveXRInterface::_get_name() const {

--- a/extension/src/TiltFiveXRInterface.h
+++ b/extension/src/TiltFiveXRInterface.h
@@ -56,6 +56,9 @@ public:
 	void stop_display(const StringName glasses_id);
 	void release_glasses(const StringName glasses_id);
 
+	PackedStringArray get_available_glasses_ids();
+	PackedStringArray get_reserved_glasses_ids();
+
 	// Overriden from XRInterfaceExtension
 	virtual StringName _get_name() const override;
 	virtual uint32_t _get_capabilities() const override;


### PR DESCRIPTION
These complements the **signal** from the system about glasses state changes. Users can get available glasses without listening for the signal or if the signal was missed.