### PR TITLE
Add Tilt Five Gameboard Node

### DIFF
--- a/example/T5Glasses.tscn
+++ b/example/T5Glasses.tscn
@@ -31,46 +31,46 @@ albedo_color = Color(0.862745, 0, 0.0235294, 1)
 size = Vector2i(2, 2)
 render_target_update_mode = 0
 
-[node name="XROrigin3D" type="XROrigin3D" parent="."]
-world_scale = 16.0
+[node name="Gameboard" type="TiltFiveGameboard" parent="."]
+gameboard_scale = 16.0
+current = true
 script = ExtResource("1_qprko")
 
-[node name="XRCamera3D" type="XRCamera3D" parent="XROrigin3D"]
+[node name="XRCamera3D" type="XRCamera3D" parent="Gameboard"]
 
-[node name="Wand_1" type="XRController3D" parent="XROrigin3D"]
+[node name="Wand_1" type="XRController3D" parent="Gameboard"]
 tracker = &"glasses/tilt_five_wand_1"
 script = ExtResource("2_qcruj")
 selected_mat = SubResource("StandardMaterial3D_cgatm")
 unselected_mat = SubResource("StandardMaterial3D_vjp8o")
 
-[node name="Controls" parent="XROrigin3D/Wand_1" instance=ExtResource("3_udc3i")]
+[node name="Controls" parent="Gameboard/Wand_1" instance=ExtResource("3_udc3i")]
 transform = Transform3D(10, 0, 0, 0, 10, 0, 0, 0, 10, 0.583, -0.002, 0.01)
 
-[node name="Center" type="MeshInstance3D" parent="XROrigin3D/Wand_1"]
+[node name="Center" type="MeshInstance3D" parent="Gameboard/Wand_1"]
 transform = Transform3D(0.1, 0, 0, 0, 0.1, 0, 0, 0, 0.1, 0, 0, 0)
 mesh = SubResource("BoxMesh_gbwc2")
 surface_material_override/0 = SubResource("StandardMaterial3D_iuako")
 
-[node name="Positive Y" type="MeshInstance3D" parent="XROrigin3D/Wand_1"]
+[node name="Positive Y" type="MeshInstance3D" parent="Gameboard/Wand_1"]
 transform = Transform3D(0.1, 0, 0, 0, 0.1, 0, 0, 0, 0.1, 0, 0.2, 0)
 mesh = SubResource("BoxMesh_gbwc2")
 surface_material_override/0 = SubResource("StandardMaterial3D_70r0u")
 
-[node name="Positive Z" type="MeshInstance3D" parent="XROrigin3D/Wand_1"]
+[node name="Positive Z" type="MeshInstance3D" parent="Gameboard/Wand_1"]
 transform = Transform3D(0.1, 0, 0, 0, 0.1, 0, 0, 0, 0.1, 0, 0, 0.2)
 mesh = SubResource("BoxMesh_gbwc2")
 surface_material_override/0 = SubResource("StandardMaterial3D_dji1h")
 
-[node name="Positive X" type="MeshInstance3D" parent="XROrigin3D/Wand_1"]
+[node name="Positive X" type="MeshInstance3D" parent="Gameboard/Wand_1"]
 transform = Transform3D(0.1, 0, 0, 0, 0.1, 0, 0, 0, 0.1, 0.2, 0, 0)
 mesh = SubResource("BoxMesh_qm7rn")
 surface_material_override/0 = SubResource("StandardMaterial3D_0arwu")
 
-[node name="OriginBased" type="MeshInstance3D" parent="XROrigin3D"]
+[node name="OriginBased" type="MeshInstance3D" parent="Gameboard"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -2.77558, 0)
 mesh = SubResource("BoxMesh_aaxuw")
-skeleton = NodePath("../../../Boxes")
 surface_material_override/0 = SubResource("StandardMaterial3D_iuako")
 
-[connection signal="button_pressed" from="XROrigin3D/Wand_1" to="XROrigin3D/Wand_1" method="_on_button_pressed"]
-[connection signal="button_released" from="XROrigin3D/Wand_1" to="XROrigin3D/Wand_1" method="_on_button_released"]
+[connection signal="button_pressed" from="Gameboard/Wand_1" to="Gameboard/Wand_1" method="_on_button_pressed"]
+[connection signal="button_released" from="Gameboard/Wand_1" to="Gameboard/Wand_1" method="_on_button_released"]

--- a/example/XROrigin3D.gd
+++ b/example/XROrigin3D.gd
@@ -1,8 +1,10 @@
-extends XROrigin3D
+extends TiltFiveGameboard
 
 var elapsed = 0.0
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _init():
+	print(gameboard_scale)
+
 func _process(delta):
 	elapsed += delta
 	position.x = sin(elapsed) * 1

--- a/example/addons/tiltfive/T5Manager.gd
+++ b/example/addons/tiltfive/T5Manager.gd
@@ -16,9 +16,9 @@ enum GlassesEvent {
 	E_STOPPED_ON_ERROR = 9
 }
 
-const xr_origin_node := ^"XROrigin3D"
+const xr_origin_node := ^"Gameboard"
 
-const wand_node_list := [^"XROrigin3D/Wand_1", ^"XROrigin3D/Wand_2", ^"XROrigin3D/Wand_3", ^"XROrigin3D/Wand_4"]
+const wand_node_list := [^"Gameboard/Wand_1", ^"Gameboard/Wand_2", ^"Gameboard/Wand_3", ^"Gameboard/Wand_4"]
 
 var tilt_five_xr_interface: TiltFiveXRInterface 
 

--- a/extension/src/TiltFiveGameboard.cpp
+++ b/extension/src/TiltFiveGameboard.cpp
@@ -1,0 +1,27 @@
+#include "TiltFiveGameboard.h"
+
+#include <godot_cpp/core/binder_common.hpp>
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+using godot::ClassDB;
+using godot::PropertyInfo;
+using godot::D_METHOD;
+
+void TiltFiveGameboard::_bind_methods() {
+	// Methods.
+	ClassDB::bind_method(D_METHOD("get_gameboard_scale"), &TiltFiveGameboard::get_gameboard_scale);
+	ClassDB::bind_method(D_METHOD("set_gameboard_scale", "scale"), &TiltFiveGameboard::set_gameboard_scale);
+
+	// Properties.
+    ClassDB::add_property("TiltFiveGameboard", PropertyInfo(Variant::FLOAT, "gameboard_scale"), "set_gameboard_scale", "get_gameboard_scale");
+}
+
+
+real_t TiltFiveGameboard::get_gameboard_scale() {
+    return _scale;
+}
+
+void TiltFiveGameboard::set_gameboard_scale(real_t scale) {
+    _scale = scale;
+}

--- a/extension/src/TiltFiveGameboard.h
+++ b/extension/src/TiltFiveGameboard.h
@@ -1,0 +1,28 @@
+#ifndef TILT_FIVE_XR_ORIGIN_H
+#define TILT_FIVE_XR_ORIGIN_H
+
+#include "TiltFiveXRInterface.h"
+
+#include <godot_cpp/classes/xr_origin3d.hpp>
+
+
+
+using godot::XROrigin3D;
+
+class TiltFiveGameboard : public XROrigin3D {
+	GDCLASS(TiltFiveGameboard, XROrigin3D);
+
+public:
+
+    real_t get_gameboard_scale();
+    void set_gameboard_scale(real_t scale);
+
+protected:
+	static void _bind_methods();
+
+private:
+    float _scale = 1.0;
+
+};
+
+#endif // TILT_FIVE_XR_ORIGIN_H

--- a/extension/src/TiltFiveXRInterface.cpp
+++ b/extension/src/TiltFiveXRInterface.cpp
@@ -1,5 +1,5 @@
 #include "TiltFiveXRInterface.h"
-
+#include "TiltFiveGameboard.h"
 #include <godot_cpp/core/class_db.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 #include <godot_cpp/classes/rendering_server.hpp>
@@ -322,13 +322,13 @@ bool TiltFiveXRInterface::_pre_draw_viewport(const RID &render_target) {
     if(!_render_glasses->is_reserved()) 
 		return false;
 
-	auto xr_origin = Object::cast_to<XROrigin3D>(ObjectDB::get_instance(entry->xr_origin_id));
+	auto xr_origin = Object::cast_to<TiltFiveGameboard>(ObjectDB::get_instance(entry->xr_origin_id));
 	if(!xr_origin)
 		return false;
 
 	xr_server->set_world_origin(xr_origin->get_global_transform());
-	xr_server->set_world_scale(xr_origin->get_world_scale());
-	
+	xr_server->set_world_scale(xr_origin->get_gameboard_scale());
+	 
 	entry->rendering = true;
 	return true;
 }

--- a/extension/src/register_types.cpp
+++ b/extension/src/register_types.cpp
@@ -1,5 +1,6 @@
 #include "register_types.h"
 #include "TiltFiveXRInterface.h"
+#include "TiltFiveGameboard.h"
 #include <gdextension_interface.h>
 #include <godot_cpp/core/class_db.hpp>
 #include <godot_cpp/core/defs.hpp>
@@ -14,6 +15,7 @@ void initialize_tiltfive_types(ModuleInitializationLevel p_level)
 		return;
 	}
 	ClassDB::register_class<TiltFiveXRInterface>();
+	ClassDB::register_class<TiltFiveGameboard>();
 
 }
 


### PR DESCRIPTION
World scale in XROrigin appears to be a global setting. It was also getting reset back to 1 randomly for some reason. Added TiltFiveGameboard to allow board to have independent scales and avoid the reset issues.