### PR TITLE
Get the gameboard type for a set of glasses

### DIFF
--- a/example/addons/tiltfive/T5Manager.gd
+++ b/example/addons/tiltfive/T5Manager.gd
@@ -74,5 +74,7 @@ func on_glasses_event(glasses_id, event_num):
 			if reserved_glasses.get(glasses_id, false):
 				reserved_glasses[glasses_id] = false
 				glasses_dropped.emit(glasses_id)
-	
+		GlassesEvent.E_TRACKING:
+			var gbt = tilt_five_xr_interface.get_gameboard_type(glasses_id)
+			print("Gameboard size = ", tilt_five_xr_interface.get_gameboard_extents(gbt))
 		

--- a/extension/T5Integration/Glasses.cpp
+++ b/extension/T5Integration/Glasses.cpp
@@ -17,6 +17,7 @@ namespace T5Integration {
 		glasses_pose.rotToGLS_GBD.y = 0;
 		glasses_pose.rotToGLS_GBD.z = 0;
 		glasses_pose.rotToGLS_GBD.w = 1;
+		glasses_pose.gameboardType = kT5_GameboardType_None;
 		left_eye_handle = 0;
 		right_eye_handle = 0;
 	}

--- a/extension/T5Integration/Glasses.h
+++ b/extension/T5Integration/Glasses.h
@@ -51,7 +51,6 @@ struct GlassesEvent {
     EType event;
 };
 
-
 class Glasses 
 {
     friend T5Service;
@@ -106,6 +105,7 @@ class Glasses
     bool update_tracking();
 
    	void get_events(int index, std::vector<GlassesEvent>& out_events);
+    T5_GameboardType get_gameboard_type();
 
 	size_t get_num_wands() { return _wand_list.size(); }
 
@@ -223,9 +223,12 @@ inline void Glasses::set_upside_down_texture(bool is_upside_down) {
     _is_upside_down_texture = is_upside_down;
 }
 
+inline T5_GameboardType Glasses::get_gameboard_type() {
+    return _swap_chain_frames[_current_frame_idx].glasses_pose.gameboardType;
+}
+
 inline GlassesFlags::FlagType Glasses::get_current_state() {
     return _state.get_current();
 }
-
 
 }

--- a/extension/T5Integration/T5Service.cpp
+++ b/extension/T5Integration/T5Service.cpp
@@ -227,4 +227,11 @@ void T5Service::get_events(std::vector<GlassesEvent>& out_events) {
 	}
 }
 
+void T5Service::get_gameboard_size(T5_GameboardType gameboard_type, T5_GameboardSize& gameboard_size) {
+	auto result = t5GetGameboardSize(_context, gameboard_type, &gameboard_size);
+	if(result != T5_SUCCESS)
+		LOG_T5_ERROR(result);
+}
+
+
 } // T5Integration

--- a/extension/T5Integration/T5Service.h
+++ b/extension/T5Integration/T5Service.h
@@ -62,6 +62,8 @@ public:
 	void* get_graphics_context_handle();
 	bool is_image_texture_array() const;
 
+	void get_gameboard_size(T5_GameboardType gameboard_type, T5_GameboardSize& gameboard_size);
+
 protected:
 
 	std::string _application_id;

--- a/extension/src/TiltFiveXRInterface.h
+++ b/extension/src/TiltFiveXRInterface.h
@@ -25,12 +25,20 @@ using godot::SubViewport;
 using godot::PackedStringArray;
 using godot::ObjectID;
 using godot::Variant;
+using godot::AABB;
 using GodotT5Integration::GodotT5Service;
 using GodotT5Integration::GodotT5Glasses;
 using T5Integration::GlassesEvent;
 
 class TiltFiveXRInterface : public XRInterfaceExtension {
 	GDCLASS(TiltFiveXRInterface, XRInterfaceExtension);
+
+	enum GameBoardType {
+		NO_GAMEBOARD_SET = kT5_GameboardType_None,
+		LE_GAMEBOARD = kT5_GameboardType_LE,
+		XE_GAMEBOARD = kT5_GameboardType_XE,
+		XE_RAISED_GAMEBOARD = kT5_GameboardType_XE_Raised
+	};
 
 	struct GlassesIndexEntry {
 		StringName id;
@@ -67,6 +75,9 @@ public:
 	void start_display(const StringName glasses_id, Variant viewport, Variant xr_origin);
 	void stop_display(const StringName glasses_id);
 	void release_glasses(const StringName glasses_id);
+
+	GameBoardType get_gameboard_type(const StringName glasses_id);	
+	AABB get_gameboard_extents(GameBoardType gameboard_type);
 
 	PackedStringArray get_available_glasses_ids();
 	PackedStringArray get_reserved_glasses_ids();
@@ -136,6 +147,8 @@ private:
 
     int reserved_glasses_count = 0;
 };
+
+VARIANT_ENUM_CAST(TiltFiveXRInterface::GameBoardType)
 
 
 VARIANT_ENUM_CAST(TiltFiveXRInterface::GlassesEventType);


### PR DESCRIPTION
Add function to get the gameboard type for a set of glasses 
Add function that returns the extents of the gameboard type with respect to its origin.