### PR TITLE
Use texture splices on main array

### DIFF
--- a/extension/src/OpenGLGlasses.cpp
+++ b/extension/src/OpenGLGlasses.cpp
@@ -52,8 +52,6 @@ void OpenGLGlasses::allocate_textures() {
 void OpenGLGlasses::deallocate_textures() {
     auto render_server = RenderingServer::get_singleton();
 
-    int width, height;
-    Glasses::get_display_size(width, height);
     for(int i = 0; i < _swap_chain_textures.size(); i++) {
         _swap_chain_textures[i].deallocate_textures();
         set_swap_chain_texture_array(i, 0);

--- a/extension/src/VulkanGlasses.cpp
+++ b/extension/src/VulkanGlasses.cpp
@@ -49,23 +49,8 @@ void VulkanGlasses::SwapChainTextures::allocate_textures(int width, int height) 
     
     render_tex = render_device->texture_create(texture_format_render, texture_view);
 
-    Ref<RDTextureFormat> texture_format_send;
-    texture_format_send.instantiate();
-
-    texture_format_send->set_texture_type(RenderingDevice::TextureType::TEXTURE_TYPE_2D);
-    texture_format_send->set_format(RenderingDevice::DataFormat::DATA_FORMAT_R8G8B8A8_UNORM);
-    texture_format_send->set_width(width);
-    texture_format_send->set_height(height);
-    texture_format_send->set_depth(1);
-    texture_format_send->set_array_layers(1);
-    texture_format_send->set_mipmaps(1);
-    texture_format_send->set_samples(RenderingDevice::TextureSamples::TEXTURE_SAMPLES_1);
-    texture_format_send->set_usage_bits(RenderingDevice::TEXTURE_USAGE_SAMPLING_BIT | RenderingDevice::TEXTURE_USAGE_CAN_COPY_TO_BIT | RenderingDevice::TEXTURE_USAGE_CAN_COPY_FROM_BIT);
-	texture_format_send->add_shareable_format(RenderingDevice::DataFormat::DATA_FORMAT_R8G8B8A8_UNORM);
-	texture_format_send->add_shareable_format(RenderingDevice::DataFormat::DATA_FORMAT_R8G8B8A8_SRGB);
-
-    left_eye_tex = render_device->texture_create(texture_format_send, texture_view);
-    right_eye_tex = render_device->texture_create(texture_format_send, texture_view);
+    left_eye_tex = render_device->texture_create_shared_from_slice(texture_view, render_tex, 0, 0);
+    right_eye_tex = render_device->texture_create_shared_from_slice(texture_view, render_tex, 1, 0);
 }
 
 void VulkanGlasses::SwapChainTextures::deallocate_textures() {
@@ -73,12 +58,12 @@ void VulkanGlasses::SwapChainTextures::deallocate_textures() {
     auto service = T5Integration::ObjectRegistry::service();
     auto render_device = render_server->get_rendering_device();
 
-    if(render_tex.is_valid())
-        render_device->free_rid(render_tex);
     if(left_eye_tex.is_valid())
         render_device->free_rid(left_eye_tex);
     if(right_eye_tex.is_valid())
         render_device->free_rid(right_eye_tex);
+    if(render_tex.is_valid())
+        render_device->free_rid(render_tex);
 }
 
 void VulkanGlasses::allocate_textures() {
@@ -101,8 +86,6 @@ void VulkanGlasses::allocate_textures() {
 void VulkanGlasses::deallocate_textures() {
     auto render_server = RenderingServer::get_singleton();
 
-    int width, height;
-    Glasses::get_display_size(width, height);
     for(int i = 0; i < _swap_chain_textures.size(); i++) {
         _swap_chain_textures[i].deallocate_textures();
         set_swap_chain_texture_pair(i, 0, 0);
@@ -119,45 +102,6 @@ void VulkanGlasses::on_glasses_released() {
 
 void VulkanGlasses::on_glasses_dropped() {
     deallocate_textures();
-}
-
-void VulkanGlasses::on_send_frame(int swap_chain_idx) {
-    auto service = T5Integration::ObjectRegistry::service();
-    if(service->get_graphics_api() == kT5_GraphicsApi_Vulkan)
-    {
-        RenderingServer *rendering_server = RenderingServer::get_singleton();
-        ERR_FAIL_NULL(rendering_server);
-        RenderingDevice *rendering_device = rendering_server->get_rendering_device();
-        ERR_FAIL_NULL(rendering_device);
-
-        auto& textures = _swap_chain_textures[swap_chain_idx];
-
-        auto size = get_render_size();
-
-        rendering_device->texture_copy(
-            textures.render_tex, // src
-            textures.left_eye_tex, // dest
-            Vector3(0,0,0), // src pos
-            Vector3(0,0,0), // dest pos
-            Vector3(size.x, size.y, 1), // size
-            0, // src mipmap
-            0, // dest mipmap
-            0, // src layer
-            0  // dest layer
-            );
-
-        rendering_device->texture_copy(
-            textures.render_tex, // src
-            textures.right_eye_tex, // dest
-            Vector3(0,0,0), // src pos
-            Vector3(0,0,0), // dest pos
-            Vector3(size.x, size.y, 1), // size
-            0, // src mipmap
-            0, // dest mipmap
-            1, // src layer
-            0  // dest layer
-            );
-    }    
 }
  
 RID VulkanGlasses::get_color_texture() 

--- a/extension/src/VulkanGlasses.h
+++ b/extension/src/VulkanGlasses.h
@@ -23,7 +23,6 @@ namespace GodotT5Integration {
         virtual void on_glasses_reserved() override;
         virtual void on_glasses_released() override;
         virtual void on_glasses_dropped() override;
-        virtual void on_send_frame(int swap_chain_idx) override;
 
         public:
 


### PR DESCRIPTION
On Vulkan you have the ability to create "views" on textures, on the Godot Rendering Device we call this "splices" as we create a view for a given splice.  This can provide access to a single mipmap or single layer of a texture.

Using this we don't need to copy the contents of each layer into separate textures, but we can access each layer individually and present them as such to TiltFive. 

Should fix #22