### PR TITLE
Refactor initialisation to Godot standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ Scons should be run from an environment that has the Microsoft x64 development t
 - Open the project in the examples directory
 - Run the default scene
 
+## Starting with a new project
+
+To use this plugin in your own project:
+- Copy the add on into your project
+- Open Project->Project Settings
+  - On the Autoload tab add `res://addons/tiltfive/T5Interface.gd`
+- Create a main scene and add a T5Manager node
+
+See example project for futher details.
+
 ## Dependencies
 
 - Uses the godot-cpp headers
@@ -39,7 +49,6 @@ Scons should be run from an environment that has the Microsoft x64 development t
 
 ## TODO
 
-- Vulkan support
 - API for tangible camera on the glasses
 - Better docs
 - Examples

--- a/example/addons/tiltfive/T5Interface.gd
+++ b/example/addons/tiltfive/T5Interface.gd
@@ -1,0 +1,61 @@
+@tool
+extends Node
+
+## This script should be configured as an autoload script.
+## It will instantiate the TileFive interface and register
+## it with the XRServer.
+##
+## It also registers various project settings the user can
+## setup.
+##
+## Note that the TiltFive interface is also registed when
+## in editor. This will allow the Godot editor to request
+## action information from the interface.
+
+var tilt_five_xr_interface: TiltFiveXRInterface 
+
+func get_tile_five_xr_interface() -> TiltFiveXRInterface:
+	return tilt_five_xr_interface
+
+func _define_project_setting(
+		p_name : String,
+		p_type : int,
+		p_hint : int = PROPERTY_HINT_NONE,
+		p_hint_string : String = "",
+		p_default_val = "") -> void:
+	# p_default_val can be any type!!
+
+	if !ProjectSettings.has_setting(p_name):
+		ProjectSettings.set_setting(p_name, p_default_val)
+
+	var property_info : Dictionary = {
+		"name" : p_name,
+		"type" : p_type,
+		"hint" : p_hint,
+		"hint_string" : p_hint_string
+	}
+
+	ProjectSettings.add_property_info(property_info)
+	ProjectSettings.set_as_basic(p_name, true)
+	ProjectSettings.set_initial_value(p_name, p_default_val)
+
+# Called when the manager is loaded and added to our scene
+func _enter_tree():
+	_define_project_setting("xr/tilt_five/application_id", TYPE_STRING, PROPERTY_HINT_NONE, "", "my.game.com")
+	_define_project_setting("xr/tilt_five/application_version", TYPE_STRING, PROPERTY_HINT_NONE, "", "0.1.0")
+	_define_project_setting("xr/tilt_five/default_display_name", TYPE_STRING, PROPERTY_HINT_NONE, "", "Game: Player One")
+
+	tilt_five_xr_interface = TiltFiveXRInterface.new();
+	if tilt_five_xr_interface:
+		tilt_five_xr_interface.application_id = ProjectSettings.get_setting_with_override("xr/tilt_five/application_id")
+		tilt_five_xr_interface.application_version = ProjectSettings.get_setting_with_override("xr/tilt_five/application_version")
+
+		XRServer.add_interface(tilt_five_xr_interface)
+
+func _exit_tree():
+	if tilt_five_xr_interface:
+		if tilt_five_xr_interface.is_initialized():
+			tilt_five_xr_interface.uninitialize()
+
+		XRServer.remove_interface(tilt_five_xr_interface)
+		tilt_five_xr_interface = null

--- a/example/project.godot
+++ b/example/project.godot
@@ -15,6 +15,10 @@ run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.1")
 config/icon="res://icon.png"
 
+[autoload]
+
+T5Interface="*res://addons/tiltfive/T5Interface.gd"
+
 [input]
 
 trigger={

--- a/extension/src/TiltFiveXRInterface.h
+++ b/extension/src/TiltFiveXRInterface.h
@@ -65,12 +65,16 @@ public:
         E_STOPPED_ON_ERROR 	= GlassesEvent::E_STOPPED_ON_ERROR
     };
 
-	// Property setters and getters);
+	// Property setters and getters.
+
+	String get_application_id() const;
+	void set_application_id(const String &p_string);
+
+	String get_application_version() const;
+	void set_application_version(const String &p_string);
 
 	// Functions.
 
-	bool start_service(const String application_id, const String application_version);
-	void stop_service();
 	void reserve_glasses(const StringName glasses_id, const String display_name);
 	void start_display(const StringName glasses_id, Variant viewport, Variant xr_origin);
 	void stop_display(const StringName glasses_id);
@@ -132,11 +136,11 @@ protected:
 
 private:
 
-	bool setup();
-	void teardown();
-
 	bool _initialised = false;
 	XRServer *xr_server = nullptr;
+
+	String application_id;
+	String application_version;
 
 	std::vector<GlassesIndexEntry> _glasses_index;
 	std::vector<GlassesEvent> _events;


### PR DESCRIPTION
This PR refactors the initialisation of the plugin to be more along the lines of the standard approach for other XR interfaces.

I've also moved the creation and registering of the interface into "T5Interface.gd" which is now loaded as an autoload script.
This also registers a number of project settings for the TileFive where we can set the application information:
![image](https://github.com/GodotVR/TiltFiveGodot4/assets/1945449/7514c521-d511-48f2-9211-ab804a529873)

I'm tempted to move the entire manager code into Autoload but think we should make that change part of the demo overhaul if we decide to do so.

Fixes #15 