### PR TITLE
Fix the swap chain frame number update

### DIFF
--- a/extension/T5Integration/Glasses.cpp
+++ b/extension/T5Integration/Glasses.cpp
@@ -543,6 +543,7 @@ namespace T5Integration {
 
 			// t5 exclusivity group 3 - serialized in main thread
 			T5_Result result = t5SendFrameToGlasses(_glasses_handle, &frameInfo);
+			_current_frame_idx = (_current_frame_idx + 1) % _swap_chain_frames.size();
 
 			LOG_TOGGLE(false, result == T5_SUCCESS, "Started sending frames", "Stoped sending frames");
 			if (result == T5_SUCCESS)
@@ -558,8 +559,6 @@ namespace T5Integration {
 			else {
 				_state.reset(GlassesState::ERROR);
 			}
-
-			_current_frame_idx = (_current_frame_idx + 1) % _swap_chain_frames.size();
 		}
 	}
 


### PR DESCRIPTION
Fixes where the next frame in the swap chain is incremented. Previously it would never be updated and therefore acted like a swap chain of length one.

This also sets the length to 1 since a larger chain seems to be introducing some sort of lag. Maybe it's interacting poorly with the pose prediction on the glasses. I'm not convinced that it's strictly necessary with T5 since the texture is not being display on the GPU but instead it is being copied out over USB. In a sense this outgoing USB queue is the swap chain.  

Anyway, I've changed it so the frame number will update correctly if it is ever set  to higher than one. I think any further investigation should go to a different PR.

Closes #22 