### PR TITLE
Fix texture copy for Forward+ renderer

### DIFF
--- a/example/project.godot
+++ b/example/project.godot
@@ -13,6 +13,7 @@ config_version=5
 config/name="TiltFiveGodot4"
 run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.1")
+run/max_fps=60
 config/icon="res://icon.png"
 
 [autoload]
@@ -32,10 +33,6 @@ trigger={
 3d_render/layer_1="All"
 3d_render/layer_2="Only spectator"
 3d_render/layer_3="Only glasses"
-
-[rendering]
-
-renderer/rendering_method="gl_compatibility"
 
 [xr]
 

--- a/extension/T5Integration/Glasses.h
+++ b/extension/T5Integration/Glasses.h
@@ -118,7 +118,10 @@ class Glasses
     void get_wand_stick(size_t wand_num, float& out_stick_x, float& out_stick_y);
     void get_wand_buttons(size_t wand_num, WandButtons& buttons);
 
+    virtual void on_post_draw() {}
+
 protected:
+
     void set_swap_chain_size(int size);
     void set_swap_chain_texture_pair(int swap_chain_idx, intptr_t left_eye_handle, intptr_t right_eye_handle);
     void set_swap_chain_texture_array(int swap_chain_idx, intptr_t array_handle);

--- a/extension/src/OpenGLGlasses.h
+++ b/extension/src/OpenGLGlasses.h
@@ -19,18 +19,20 @@ namespace GodotT5Integration {
             Ref<Texture2DArray> render_tex;
         };
 
+        public:
+
+        OpenGLGlasses(std::string_view id);
+    
+        virtual RID get_color_texture() override;
+
+        private:
+
         void allocate_textures();
         void deallocate_textures();
 
         virtual void on_glasses_reserved() override;
         virtual void on_glasses_released() override;
         virtual void on_glasses_dropped() override;
-
-        public:
-
-        OpenGLGlasses(std::string_view id);
-    
-        virtual RID get_color_texture() override;
 
         private:
 

--- a/extension/src/TiltFiveXRInterface.cpp
+++ b/extension/src/TiltFiveXRInterface.cpp
@@ -372,22 +372,11 @@ bool TiltFiveXRInterface::_pre_draw_viewport(const RID &render_target) {
 }
 
 void TiltFiveXRInterface::_post_draw_viewport(const RID &render_target, const Rect2 &screen_rect) {
-	Rect2 src_rect(0.0f, 0.0f, 1.0f, 1.0f);
-	Rect2 dst_rect = screen_rect;
-
-	// halve our width
-	Vector2 size = dst_rect.get_size();
-	size.x = size.x * 0.5;
-	dst_rect.size = size;
-
-	Vector2 eye_center(0.0, 0.0);
-
-	//add_blit(render_target, src_rect, screen_rect, true, 0, false, eye_center, 0, 0, 0, 0);
+	_render_glasses->on_post_draw();
 	_render_glasses.reset();
 }
 
 void TiltFiveXRInterface::_end_frame() {
-
 	for(auto& entry : _glasses_index) {
 		if(entry.rendering) {
 			entry.glasses.lock()->send_frame();
@@ -418,7 +407,6 @@ PackedStringArray TiltFiveXRInterface::_get_suggested_pose_names(const StringNam
 }
 
 void TiltFiveXRInterface::_process() {
-
 	if(!t5_service) return;
 
 	t5_service->update_connection();

--- a/extension/src/VulkanGlasses.cpp
+++ b/extension/src/VulkanGlasses.cpp
@@ -49,8 +49,23 @@ void VulkanGlasses::SwapChainTextures::allocate_textures(int width, int height) 
     
     render_tex = render_device->texture_create(texture_format_render, texture_view);
 
-    left_eye_tex = render_device->texture_create_shared_from_slice(texture_view, render_tex, 0, 0);
-    right_eye_tex = render_device->texture_create_shared_from_slice(texture_view, render_tex, 1, 0);
+    Ref<RDTextureFormat> texture_format_send;
+    texture_format_send.instantiate();
+
+    texture_format_send->set_texture_type(RenderingDevice::TextureType::TEXTURE_TYPE_2D);
+    texture_format_send->set_format(RenderingDevice::DataFormat::DATA_FORMAT_R8G8B8A8_UNORM);
+    texture_format_send->set_width(width);
+    texture_format_send->set_height(height);
+    texture_format_send->set_depth(1);
+    texture_format_send->set_array_layers(1);
+    texture_format_send->set_mipmaps(1);
+    texture_format_send->set_samples(RenderingDevice::TextureSamples::TEXTURE_SAMPLES_1);
+    texture_format_send->set_usage_bits(RenderingDevice::TEXTURE_USAGE_SAMPLING_BIT | RenderingDevice::TEXTURE_USAGE_CAN_COPY_TO_BIT | RenderingDevice::TEXTURE_USAGE_CAN_COPY_FROM_BIT);
+	texture_format_send->add_shareable_format(RenderingDevice::DataFormat::DATA_FORMAT_R8G8B8A8_UNORM);
+	texture_format_send->add_shareable_format(RenderingDevice::DataFormat::DATA_FORMAT_R8G8B8A8_SRGB);
+
+    left_eye_tex = render_device->texture_create(texture_format_send, texture_view);
+    right_eye_tex = render_device->texture_create(texture_format_send, texture_view);
 }
 
 void VulkanGlasses::SwapChainTextures::deallocate_textures() {
@@ -105,6 +120,46 @@ void VulkanGlasses::on_glasses_released() {
 void VulkanGlasses::on_glasses_dropped() {
     GodotT5Glasses::on_glasses_dropped();
     deallocate_textures();
+}
+
+
+void VulkanGlasses::on_post_draw() {
+    auto service = T5Integration::ObjectRegistry::service();
+    if(service->get_graphics_api() == kT5_GraphicsApi_Vulkan)
+    {
+        RenderingServer *rendering_server = RenderingServer::get_singleton();
+        ERR_FAIL_NULL(rendering_server);
+        RenderingDevice *rendering_device = rendering_server->get_rendering_device();
+        ERR_FAIL_NULL(rendering_device);
+
+        auto& textures = _swap_chain_textures[get_current_frame_idx()];
+
+        auto size = get_render_size();
+
+        rendering_device->texture_copy(
+            textures.render_tex, // src
+            textures.left_eye_tex, // dest
+            Vector3(0,0,0), // src pos
+            Vector3(0,0,0), // dest pos
+            Vector3(size.x, size.y, 1), // size
+            0, // src mipmap
+            0, // dest mipmap
+            0, // src layer
+            0  // dest layer
+            );
+
+        rendering_device->texture_copy(
+            textures.render_tex, // src
+            textures.right_eye_tex, // dest
+            Vector3(0,0,0), // src pos
+            Vector3(0,0,0), // dest pos
+            Vector3(size.x, size.y, 1), // size
+            0, // src mipmap
+            0, // dest mipmap
+            1, // src layer
+            0  // dest layer
+            );
+    }
 }
  
 RID VulkanGlasses::get_color_texture() 

--- a/extension/src/VulkanGlasses.h
+++ b/extension/src/VulkanGlasses.h
@@ -17,6 +17,15 @@ namespace GodotT5Integration {
             RID right_eye_tex;
         };
 
+        public:
+
+        VulkanGlasses(std::string_view id);
+    
+        virtual void on_post_draw() override;
+        virtual RID get_color_texture() override;
+
+        private:
+
         void allocate_textures();
         void deallocate_textures();
 
@@ -24,11 +33,6 @@ namespace GodotT5Integration {
         virtual void on_glasses_released() override;
         virtual void on_glasses_dropped() override;
 
-        public:
-
-        VulkanGlasses(std::string_view id);
-    
-        virtual RID get_color_texture() override;
 
         private:
 


### PR DESCRIPTION
Moved the texture copy from XRInterfaceExtension's the _end_frame to _post_draw_viewport. This seems to fix the fix the barrier issue with T5's rendering. Output seems smooth now with no glitches.