### PR TITLE
Automatically scale glasses and wand to current gameboard scale

### DIFF
--- a/example.gd/addons/tiltfive/assets/T5GlassesModel.tscn
+++ b/example.gd/addons/tiltfive/assets/T5GlassesModel.tscn
@@ -1,5 +1,10 @@
-[gd_scene load_steps=2 format=3 uid="uid://b1cd3jc00rhal"]
+[gd_scene load_steps=3 format=3 uid="uid://b1cd3jc00rhal"]
 
 [ext_resource type="PackedScene" uid="uid://c44ott7hdtkjs" path="res://addons/tiltfive/assets/T5-glasses.glb" id="1_22or3"]
+[ext_resource type="Script" path="res://addons/tiltfive/assets/auto_scale.gd" id="2_w6vky"]
 
 [node name="T5-glasses" instance=ExtResource("1_22or3")]
+script = ExtResource("2_w6vky")
+
+[node name="Cube" parent="." index="0"]
+layers = 2

--- a/example.gd/addons/tiltfive/assets/T5WandModel.tscn
+++ b/example.gd/addons/tiltfive/assets/T5WandModel.tscn
@@ -1,5 +1,11 @@
-[gd_scene load_steps=2 format=3 uid="uid://fipea8dbocg4"]
+[gd_scene load_steps=3 format=3 uid="uid://fipea8dbocg4"]
 
 [ext_resource type="PackedScene" uid="uid://bggv3rg34lcs6" path="res://addons/tiltfive/assets/T5-wand.glb" id="1_rqv18"]
+[ext_resource type="Script" path="res://addons/tiltfive/assets/auto_scale.gd" id="2_t5vy4"]
 
 [node name="T5-wand" instance=ExtResource("1_rqv18")]
+script = ExtResource("2_t5vy4")
+
+[node name="Roundcube_001" parent="." index="0"]
+transform = Transform3D(0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5, 0, 0, 0)
+layers = 2

--- a/example.gd/addons/tiltfive/assets/auto_scale.gd
+++ b/example.gd/addons/tiltfive/assets/auto_scale.gd
@@ -1,0 +1,25 @@
+extends Node3D
+
+var origin : T5Origin3D
+var gameboard_scale : float = 1.0
+
+func _find_origin():
+	var parent = get_parent()
+	while parent and !origin:
+		if parent is T5Origin3D:
+			origin = parent
+			return
+		
+		parent = parent.get_parent()
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	_find_origin()
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	if origin and origin.gameboard_scale != gameboard_scale:
+		gameboard_scale = origin.gameboard_scale
+		scale = Vector3(gameboard_scale, gameboard_scale, gameboard_scale)


### PR DESCRIPTION
In our demo the glasses and wand have a hardcoded scale, while experimenting with a larger project where the scale changed, the wand and glasses weren't adjusted.

So this PR adds a little script on the two scenes that ensures they are automatically adjusted when the scale of the gameboard changes.