### PR TITLE
Fixes for initialization and glasses state management

### DIFF
--- a/example.gd/addons/tiltfive/tiltfive.gdextension
+++ b/example.gd/addons/tiltfive/tiltfive.gdextension
@@ -10,6 +10,9 @@ T5Gameboard = "res://addons/tiltfive/assets/board.svg"
 
 windows.x86_64.debug = "res://addons/tiltfive/bin/libgdtiltfive.windows.template_debug.x86_64.dll"
 windows.x86_64.release = "res://addons/tiltfive/bin/libgdtiltfive.windows.template_release.x86_64.dll"
+linux.x86_64.debug = "res://addons/tiltfive/bin/libgdtiltfive.linux.template_debug.x86_64.so"
+linux.x86_64.release = "res://addons/tiltfive/bin/libgdtiltfive.linux.template_release.x86_64.so"
+
 
 [dependencies]
 
@@ -18,5 +21,11 @@ windows.x86_64.debug = {
 }
 windows.x86_64.release = {
     "res://addons/tiltfive/bin/TiltFiveNative.dll" : ""
+}
+linux.x86_64.debug = {
+    "res://addons/tiltfive/bin/libTiltFiveNative.so" : ""
+}
+linux.x86_64.release = {
+    "res://addons/tiltfive/bin/libTiltFiveNative.so" : ""
 }
 

--- a/extension/T5Integration/Glasses.h
+++ b/extension/T5Integration/Glasses.h
@@ -17,16 +17,17 @@ using TaskSystem::Scheduler;
 float const g_default_fov = 48.0f;
 
 namespace GlassesState {
-	const uint16_t READY				= 0x00000001; //000000001
-	const uint16_t GRAPHICS_INIT		= 0x00000002; //000000010
-	const uint16_t SUSTAIN_CONNECTION	= 0x00000004; //000000100
+	const uint16_t READY				= 0x00000001; //0000000001
+	const uint16_t GRAPHICS_INIT		= 0x00000002; //0000000010
+	const uint16_t SUSTAIN_CONNECTION	= 0x00000004; //0000000100
 
-	const uint16_t CREATED				= 0x00000008; //000001000
-	const uint16_t UNAVAILABLE			= 0x00000010; //000010000
-	const uint16_t TRACKING				= 0x00000020; //000100000
-	const uint16_t CONNECTED			= 0x00000040; //001000000
-	const uint16_t TRACKING_WANDS		= 0x00000080; //010000000
-	const uint16_t ERROR				= 0x00000100; //100000000
+	const uint16_t CREATED				= 0x00000008; //0000001000
+	const uint16_t UNAVAILABLE			= 0x00000010; //0000010000
+	const uint16_t TRACKING				= 0x00000020; //0000100000
+	const uint16_t CONNECTED			= 0x00000040; //0001000000
+	const uint16_t TRACKING_WANDS		= 0x00000080; //0010000000
+	const uint16_t ERROR				= 0x00000100; //0100000000
+	const uint16_t DISPLAY_STARTED		= 0x00000200; //1000000000
 }
 
 struct GlassesEvent {
@@ -82,10 +83,13 @@ class Glasses
     bool is_available();
     bool is_tracking();
     
-   bool allocate_handle(T5_Context context);
+    bool allocate_handle(T5_Context context);
     void destroy_handle();
     void connect(const std::string_view application_name);
     void disconnect();
+	void start_display();
+	void stop_display();
+
 
     float get_ipd();
     float get_fov();
@@ -128,6 +132,8 @@ protected:
     void set_swap_chain_texture_pair(int swap_chain_idx, intptr_t left_eye_handle, intptr_t right_eye_handle);
     void set_swap_chain_texture_array(int swap_chain_idx, intptr_t array_handle);
 
+	virtual void on_start_display() {}
+	virtual void on_stop_display() {}
     virtual void on_glasses_reserved() {}
     virtual void on_glasses_released() {}
     virtual void on_glasses_dropped() {}
@@ -172,6 +178,8 @@ private:
 	float _ipd = 0.059f;
 
 	GlassesFlags _state;
+	GlassesFlags _previous_event_state;
+	GlassesFlags _previous_update_state;
 
     bool _is_upside_down_texture = false;
 

--- a/extension/T5Integration/Logging.h
+++ b/extension/T5Integration/Logging.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <memory>
+#include <sstream>
 #include <TiltFiveNative.h>
 
 namespace T5Integration {
@@ -56,6 +57,10 @@ void log_message(T var1, Types... var2) {
 
 #ifndef LOG_TOGGLE
 #define LOG_TOGGLE(INIT, TEST, MSG1, MSG2) { static bool toggle ## __LINE__ = (INIT);  T5Integration::log_toggle((TEST), toggle ## __LINE__, MSG1, MSG2); }
+#endif
+
+#ifndef LOG_MESSAGE
+#define LOG_MESSAGE(...) T5Integration::log_message(__func__, ":", __LINE__, " ", __VA_ARGS__)
 #endif
 
 #ifndef LOG_ERROR

--- a/extension/T5Integration/T5Service.h
+++ b/extension/T5Integration/T5Service.h
@@ -111,6 +111,7 @@ protected:
 	std::vector<Glasses::Ptr> _glasses_list;
 
 	T5ServiceFlags _state;
+	T5ServiceFlags _previous_event_state;
 
 	std::chrono::milliseconds _poll_rate_for_monitoring = 2s;
 	std::chrono::milliseconds _poll_rate_for_retry = 100ms;

--- a/extension/T5Integration/Wand.cpp
+++ b/extension/T5Integration/Wand.cpp
@@ -151,8 +151,8 @@ void WandService::monitor_wands(std::stop_token s_token) {
 
 		if(event.type != kT5_WandStreamEventType_Desync) {
 			std::lock_guard lock(_list_access);
-			auto opt_wand_ptr = find_wand(_wand_list, event.wandId);
-			auto wand = opt_wand_ptr ? opt_wand_ptr.value() : &_wand_list.emplace_back();
+			auto wand_ptr = find_wand(_wand_list, event.wandId);
+			auto wand = wand_ptr ? wand_ptr : &_wand_list.emplace_back();
 			wand->update_from_stream_event(event);
 		}
 		else {

--- a/extension/T5Integration/Wand.h
+++ b/extension/T5Integration/Wand.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <thread>
 #include <chrono>
+#include <vector>
 #include <TiltFiveNative.h>
 
 
@@ -81,15 +82,15 @@ private:
 	T5_Result _last_wand_error;
 };
 
-inline std::optional<Wand*> find_wand(const WandList& list, T5_WandHandle handle) {
+inline Wand* find_wand(WandList& list, T5_WandHandle handle) {
 	auto it = std::find_if(list.begin(), list.end(),
 						   [handle](auto& test_wand) {
 							   return test_wand._handle == handle;
 						   });
 
 	if(it != list.end())
-		return it._Ptr;
-	return std::nullopt;
+		return std::addressof(*it);
+	return nullptr;
 }
 
 } // T5Integration

--- a/extension/src/GodotT5Glasses.cpp
+++ b/extension/src/GodotT5Glasses.cpp
@@ -97,11 +97,12 @@ void GodotT5Glasses::on_glasses_reserved() {
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL(xr_server);
 
-	auto tracker_name = std::format("/user/{}/head", get_id());
+    char buffer[64];
+    ERR_FAIL_COND(snprintf(buffer, 64, "/user/%s/head", get_id().c_str()) > 64);
 
 	_head.instantiate();
 	_head->set_tracker_type(XRServer::TRACKER_HEAD);
-	_head->set_tracker_name(tracker_name.c_str());
+	_head->set_tracker_name(buffer);
 	_head->set_tracker_desc("Players head");
 	xr_server->add_tracker(_head);    
 }
@@ -166,11 +167,12 @@ void GodotT5Glasses::add_tracker() {
 	Ref<XRPositionalTracker> positional_tracker;
 	positional_tracker.instantiate();
 
-	auto tracker_name = std::format("/user/{}/wand_{}", get_id(), new_id);
+    char buffer[64];
+    ERR_FAIL_COND(snprintf(buffer, 64, "/user/%s/wand_%d", get_id().c_str(), new_id) > 64);
  
-	positional_tracker->set_tracker_type(XRServer::TRACKER_CONTROLLER);
-	positional_tracker->set_tracker_name(tracker_name.c_str());
-	positional_tracker->set_tracker_desc(tracker_name.c_str());
+    positional_tracker->set_tracker_type(XRServer::TRACKER_CONTROLLER);
+    positional_tracker->set_tracker_name(buffer);
+    positional_tracker->set_tracker_desc("Tracks wand");
 
 	_wand_trackers.push_back(positional_tracker);    
 }

--- a/extension/src/OpenGLGlasses.cpp
+++ b/extension/src/OpenGLGlasses.cpp
@@ -20,7 +20,8 @@ OpenGLGlasses::OpenGLGlasses(std::string_view id)
 void OpenGLGlasses::SwapChainTextures::allocate_textures(int width, int height) {
     auto render_server = RenderingServer::get_singleton();
 
-    deallocate_textures();
+	if(is_allocated)
+    	deallocate_textures();
 
     Ref<Image> dummy_image = Image::create(width, height, false, godot::Image::FORMAT_RGBA8);
     godot::Color bg(0,0,0);
@@ -32,10 +33,13 @@ void OpenGLGlasses::SwapChainTextures::allocate_textures(int width, int height) 
 
     render_tex.instantiate();
     render_tex->create_from_images(image_arr);
+
+	is_allocated = true;
 }
 
 void OpenGLGlasses::SwapChainTextures::deallocate_textures() {
     render_tex.unref();
+	is_allocated = false;
 }
 
 void OpenGLGlasses::allocate_textures() {
@@ -58,18 +62,11 @@ void OpenGLGlasses::deallocate_textures() {
     }
 }
 
-void OpenGLGlasses::on_glasses_reserved() {
-    GodotT5Glasses::on_glasses_reserved();
+void OpenGLGlasses::on_start_display() {
     allocate_textures();
 }
 
-void OpenGLGlasses::on_glasses_released() {
-    GodotT5Glasses::on_glasses_released();
-    deallocate_textures();
-}
-
-void OpenGLGlasses::on_glasses_dropped() {
-    GodotT5Glasses::on_glasses_dropped();
+void OpenGLGlasses::on_stop_display()  {
     deallocate_textures();
 }
 

--- a/extension/src/OpenGLGlasses.h
+++ b/extension/src/OpenGLGlasses.h
@@ -16,6 +16,7 @@ namespace GodotT5Integration {
             void allocate_textures(int width, int height);
             void deallocate_textures();
 
+			bool is_allocated = false;
             Ref<Texture2DArray> render_tex;
         };
 
@@ -30,9 +31,8 @@ namespace GodotT5Integration {
         void allocate_textures();
         void deallocate_textures();
 
-        virtual void on_glasses_reserved() override;
-        virtual void on_glasses_released() override;
-        virtual void on_glasses_dropped() override;
+		virtual void on_start_display() override;
+		virtual void on_stop_display() override;
 
         private:
 

--- a/extension/src/TiltFiveXRInterface.cpp
+++ b/extension/src/TiltFiveXRInterface.cpp
@@ -205,6 +205,7 @@ void TiltFiveXRInterface::_start_display(TiltFiveXRInterface::GlassesIndexEntry&
 		WARN_PRINT("Glasses need to be reserved to display viewport");
 		return;
 	}
+	glasses->start_display();
 	entry.viewport_id = viewport->get_instance_id();
 	entry.gameboard_id = gameboard->get_instance_id();
 
@@ -220,11 +221,13 @@ void TiltFiveXRInterface::stop_display(const StringName glasses_id) {
 
 
 void TiltFiveXRInterface::_stop_display(GlassesIndexEntry& entry) {
+	auto glasses = entry.glasses.lock();
 	auto viewport = Object::cast_to<SubViewport>(ObjectDB::get_instance(entry.viewport_id));
 	if(viewport) {
 		viewport->set_use_xr(false);
 		viewport->set_update_mode(godot::SubViewport::UpdateMode::UPDATE_DISABLED);
 	}
+	glasses->stop_display();
 	entry.viewport_id = ObjectID();
 	entry.gameboard_id = ObjectID();
 }

--- a/extension/src/VulkanGlasses.h
+++ b/extension/src/VulkanGlasses.h
@@ -12,6 +12,7 @@ namespace GodotT5Integration {
             void allocate_textures(int width, int height);
             void deallocate_textures();
 
+			bool is_allocated = false;
             RID render_tex;
             RID left_eye_tex;
             RID right_eye_tex;
@@ -31,10 +32,8 @@ namespace GodotT5Integration {
         void allocate_textures();
         void deallocate_textures();
 
-        virtual void on_glasses_reserved() override;
-        virtual void on_glasses_released() override;
-        virtual void on_glasses_dropped() override;
-
+		virtual void on_start_display() override;
+		virtual void on_stop_display() override;
 
         private:
 


### PR DESCRIPTION
In the process of working on a Linux version some problems were found in initialization and glasses state management. Since they are relevant to other platforms I've pulled these fixes together here. I have excluded changes to `build-on-push.yml` because the Linux version of the plugin still has some issues to work out.

Problems and fixes:
1) A race condition was found in initialization that would cause rendering to start before frame textures had been created. This was caused when the READY state flipped between the `update_connection()` call and the `get_events()` call. The solution implemented was to move the graphics initialization into the `start_display()` function call chain. Since this is the function that starts rendering it can ensure that textures are setup first.

2. Although it has never seemed to come up, there are situations where previous state variable might be reset before changes could be detected. The fix for this was stop using a single var for this and track separate vars in each place changes needed to be detected.

3. There are a few minor changes to account for differences in C++ library functions between Windows and Linux.

4. Update SConstruct for Linux build