### PR TITLE
Change application/version setting source to remove redundancy

### DIFF
--- a/example.csharp/addons/tiltfive/T5ProjectSettings.cs
+++ b/example.csharp/addons/tiltfive/T5ProjectSettings.cs
@@ -27,9 +27,7 @@ public static class T5ProjectSettings
 
 	public static void setup_properties() {
 		if (!isInitialized) {
-			DefineProjectSetting("xr/tilt_five/application_id", Variant.Type.String, PropertyHint.None, "", "my.game.com");
-			DefineProjectSetting("xr/tilt_five/application_version", Variant.Type.String, PropertyHint.None, "", "0.1.0");
-			DefineProjectSetting("xr/tilt_five/default_display_name", Variant.Type.String, PropertyHint.None, "", "Game: Player One");
+			DefineProjectSetting("xr/tilt_five/default_display_name", Variant.Type.String, PropertyHint.None, "", "");
 			DefineProjectSetting("xr/tilt_five/trigger_click_threshhold", Variant.Type.Float, PropertyHint.Range, "0,1,0.01", 0.3);
 
 			isInitialized = true;
@@ -38,17 +36,33 @@ public static class T5ProjectSettings
 
 	public static String ApplicationID
 	{
-		get { setup_properties();  return ProjectSettings.GetSettingWithOverride("xr/tilt_five/application_id").AsString(); }
+		get {
+			var app_id = ProjectSettings.GetSettingWithOverride("application/config/name").AsString();
+			if (app_id == null || app_id == "")
+				return "tiltfive.godot.game";
+			return  app_id;
+		}
 	}
 
 	public static String ApplicationVersion
 	{
-		get { setup_properties(); return ProjectSettings.GetSettingWithOverride("xr/tilt_five/application_version").AsString(); }
+		get {
+			var version = ProjectSettings.GetSettingWithOverride("application/config/version").AsString();
+			if (version == null || version == "")
+				return "unknown";
+			return  version;
+		}
 	}
 
 	public static String DefaultDisplayName
 	{
-		get { setup_properties(); return ProjectSettings.GetSettingWithOverride("xr/tilt_five/default_display_name").AsString(); }
+		get { 
+			setup_properties(); 
+			var disp_name = ProjectSettings.GetSettingWithOverride("xr/tilt_five/default_display_name").AsString();
+			if (disp_name == null || disp_name == "")
+				return ApplicationID;
+			return disp_name; 
+		}
 	}
 
 	public static float TriggerClickThreshhold

--- a/example.gd/addons/tiltfive/T5ProjectSettings.gd
+++ b/example.gd/addons/tiltfive/T5ProjectSettings.gd
@@ -27,28 +27,34 @@ static func _define_project_setting(
 
 static func setup_properties():
 	if not _initialized:
-		_define_project_setting("xr/tilt_five/application_id", TYPE_STRING, PROPERTY_HINT_NONE, "", "my.game.com")
-		_define_project_setting("xr/tilt_five/application_version", TYPE_STRING, PROPERTY_HINT_NONE, "", "0.1.0")
-		_define_project_setting("xr/tilt_five/default_display_name", TYPE_STRING, PROPERTY_HINT_NONE, "", "Game: Player One")
+		_define_project_setting("xr/tilt_five/default_display_name", TYPE_STRING)
 		_define_project_setting("xr/tilt_five/trigger_click_threshhold", TYPE_FLOAT, PROPERTY_HINT_RANGE, "0,1,0.01", 0.3)
 		_initialized = true
 
 static var application_id : String:
 	get:
-		setup_properties()
-		return ProjectSettings.get_setting_with_override("xr/tilt_five/application_id")
+		var app_id := ProjectSettings.get_setting_with_override("application/config/name")
+		if not app_id or app_id == "":
+			return "tiltfive.godot.game"
+		return app_id
 
 static var application_version : String:
 	get:
-		setup_properties()
-		return ProjectSettings.get_setting_with_override("xr/tilt_five/application_version")
-
+		var version := ProjectSettings.get_setting_with_override("application/config/version")
+		if not version or version == "":
+			return "unknown"
+		return version
+		
 static var default_display_name : String:
 	get:
 		setup_properties()
-		return ProjectSettings.get_setting_with_override("xr/tilt_five/default_display_name")
+		var disp_name := ProjectSettings.get_setting_with_override("xr/tilt_five/default_display_name")
+		if not disp_name or disp_name == "":
+			return T5ProjectSettings.application_id
+		return disp_name
 
 static var trigger_click_threshhold : float:
 	get:
 		setup_properties()
 		return ProjectSettings.get_setting_with_override("xr/tilt_five/trigger_click_threshhold")
+		


### PR DESCRIPTION
This change remaps some settings
It removes `xr/tilt_five/application_id` and uses  `application/config/name` instead. 
It removes `xr/tilt_five/application_version` and uses `application/config/version` instead.

This change is in alignment with the intended use of these fields for identifying the application in the T5 service logging.

Additionally if `xr/tilt_five/default_display_name` does not have a supplied value `application/config/name` is used.