### PR TITLE
Add a debug log setting

### DIFF
--- a/example.csharp/addons/tiltfive/T5Interface.cs
+++ b/example.csharp/addons/tiltfive/T5Interface.cs
@@ -51,6 +51,7 @@ public partial class T5Interface : Node
 		xrInterface.Set("application_id", T5ProjectSettings.ApplicationID);
 		xrInterface.Set("application_version", T5ProjectSettings.ApplicationVersion);
 		xrInterface.Set("trigger_click_threshold", T5ProjectSettings.TriggerClickThreshhold);
+		xrInterface.Set("debug_logging", T5ProjectSettings.IsDebugLogging);
 
 		XRServer.AddInterface(xrInterface as XRInterface);
 
@@ -118,26 +119,14 @@ public partial class T5Interface : Node
 
 		switch ((GlassesEventType)eventNum)
 		{
-			case GlassesEventType.E_GLASSES_ADDED:
-			{
-				GD.Print(glassesID, " E_GLASSES_ADDED");
-				break;
-			}
-			case GlassesEventType.E_GLASSES_LOST:
-			{
-				GD.Print(glassesID, " E_GLASSES_LOST");
-				break;
-			}
 			case GlassesEventType.E_GLASSES_AVAILABLE:
 			{ 
-				GD.Print(glassesID, " E_GLASSES_AVAILABLE");
 				xrRigState.available = true;
 				ProcessGlasses();
 				break;
 			}
 			case GlassesEventType.E_GLASSES_UNAVAILABLE:
 			{ 
-				GD.Print(glassesID, " E_GLASSES_UNAVAILABLE");
 				xrRigState.available = false;
 				if(xrRigState.attemptingToReserve)
 				{
@@ -148,8 +137,6 @@ public partial class T5Interface : Node
 			}
 			case GlassesEventType.E_GLASSES_RESERVED:
 			{ 
-				GD.Print(glassesID, " E_GLASSES_RESERVED");
-
 				xrRigState.reserved = true;
 				xrRigState.attemptingToReserve = false;
 
@@ -170,8 +157,6 @@ public partial class T5Interface : Node
 			}
 			case GlassesEventType.E_GLASSES_DROPPED:
 			{ 
-				GD.Print(glassesID, " E_DROPPED");
-
 				xrRigState.reserved = false;
 				xrRigState.attemptingToReserve = false;
 
@@ -187,7 +172,6 @@ public partial class T5Interface : Node
 			}
 			case GlassesEventType.E_GLASSES_TRACKING:
 			{
-				GD.Print(glassesID, " E_GLASSES_TRACKING");
 				var gbt = xrInterface.Call("get_gameboard_type", glassesID).As<T5Def.GameboardType>();
 				if(xrRigState.gameboardType != gbt)
 				{
@@ -201,16 +185,8 @@ public partial class T5Interface : Node
 				}
 				break;
 			}
-			case GlassesEventType.E_GLASSES_NOT_TRACKING:
-			{
-				GD.Print(glassesID, " E_GLASSES_NOT_TRACKING");
-				break;
-			}
-			default:
-			{
-				GD.PrintErr(glassesID, " unknown event");
-				break;
-			}
+			// This is the only set of events that needs to be handled
+			default: break;
 		}
 
 	}

--- a/example.csharp/addons/tiltfive/T5ProjectSettings.cs
+++ b/example.csharp/addons/tiltfive/T5ProjectSettings.cs
@@ -31,6 +31,7 @@ public static class T5ProjectSettings
 			DefineProjectSetting("xr/tilt_five/application_version", Variant.Type.String, PropertyHint.None, "", "0.1.0");
 			DefineProjectSetting("xr/tilt_five/default_display_name", Variant.Type.String, PropertyHint.None, "", "Game: Player One");
 			DefineProjectSetting("xr/tilt_five/trigger_click_threshhold", Variant.Type.Float, PropertyHint.Range, "0,1,0.01", 0.3);
+			DefineProjectSetting("xr/tilt_five/debug_logging", Variant.Type.Bool, PropertyHint.None, "", false);
 
 			isInitialized = true;
 		}
@@ -54,6 +55,11 @@ public static class T5ProjectSettings
 	public static float TriggerClickThreshhold
 	{
 		get { setup_properties(); return (float)ProjectSettings.GetSettingWithOverride("xr/tilt_five/trigger_click_threshhold").AsDouble(); }
+	}
+
+	public static bool IsDebugLogging
+	{
+		get { setup_properties(); return ProjectSettings.GetSettingWithOverride("xr/tilt_five/debug_logging").AsBool(); }
 	}
 }
 

--- a/example.gd/addons/tiltfive/T5ProjectSettings.gd
+++ b/example.gd/addons/tiltfive/T5ProjectSettings.gd
@@ -31,6 +31,7 @@ static func setup_properties():
 		_define_project_setting("xr/tilt_five/application_version", TYPE_STRING, PROPERTY_HINT_NONE, "", "0.1.0")
 		_define_project_setting("xr/tilt_five/default_display_name", TYPE_STRING, PROPERTY_HINT_NONE, "", "Game: Player One")
 		_define_project_setting("xr/tilt_five/trigger_click_threshhold", TYPE_FLOAT, PROPERTY_HINT_RANGE, "0,1,0.01", 0.3)
+		_define_project_setting("xr/tilt_five/debug_logging", TYPE_BOOL, PROPERTY_HINT_NONE, "", false)
 		_initialized = true
 
 static var application_id : String:
@@ -52,3 +53,8 @@ static var trigger_click_threshhold : float:
 	get:
 		setup_properties()
 		return ProjectSettings.get_setting_with_override("xr/tilt_five/trigger_click_threshhold")
+
+static var is_debug_logging : bool:
+	get:
+		setup_properties()
+		return ProjectSettings.get_setting_with_override("xr/tilt_five/debug_logging")

--- a/extension/T5Integration/Logging.h
+++ b/extension/T5Integration/Logging.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <TiltFiveNative.h>
+#include <iostream>
 #include <memory>
 #include <sstream>
 
@@ -12,6 +13,13 @@ public:
 	virtual void log_error(const char* message, const char* func_name, const char* file_name, int line_num) = 0;
 	virtual void log_warning(const char* message, const char* func_name, const char* file_name, int line_num) = 0;
 	virtual void log_string(const char* message) = 0;
+	void set_debug(bool is_debug_) {
+		is_debug = is_debug_;
+	}
+	bool get_debug() { return is_debug; }
+
+private:
+	bool is_debug = false;
 };
 
 class DefaultLogger : public Logger {

--- a/extension/src/GodotT5Service.cpp
+++ b/extension/src/GodotT5Service.cpp
@@ -100,12 +100,15 @@ void GodotT5Logger::log_error(const char* message, const char* func_name, const 
 }
 
 void GodotT5Logger::log_warning(const char* message, const char* func_name, const char* file_name, int line_num) {
-	godot::_err_print_error(func_name, file_name, line_num, "TiltFiveXRInterface", message, true, false);
+	godot::_err_print_error(func_name, file_name, line_num, "TiltFiveXRInterface", message, true, true);
 }
 
 void GodotT5Logger::log_string(const char* message) {
 	Variant v_msg = message;
-	UtilityFunctions::print_verbose(v_msg);
+	if (get_debug())
+		UtilityFunctions::print(v_msg);
+	else
+		UtilityFunctions::print_verbose(v_msg);
 }
 
 GodotT5Service::Ptr GodotT5ObjectRegistry::service() {
@@ -135,15 +138,15 @@ T5Integration::T5Math::Ptr GodotT5ObjectRegistry::get_math() {
 	return math;
 }
 
+GodotT5Logger::Ptr g_logger;
+
 T5Integration::Logger::Ptr GodotT5ObjectRegistry::get_logger() {
-	GodotT5Logger::Ptr logger;
-	if (_logger.expired()) {
-		logger = std::make_shared<GodotT5Logger>();
-		_logger = logger;
-	} else {
-		logger = std::static_pointer_cast<GodotT5Logger>(_logger.lock());
+	if (!g_logger) {
+		g_logger = std::make_shared<GodotT5Logger>();
+		_logger = g_logger;
 	}
-	return logger;
+
+	return g_logger;
 }
 
 } //namespace GodotT5Integration

--- a/extension/src/TiltFiveXRInterface.h
+++ b/extension/src/TiltFiveXRInterface.h
@@ -92,6 +92,9 @@ public:
 	float get_trigger_click_threshold();
 	void set_trigger_click_threshold(float threshold);
 
+	bool get_debug_logging();
+	void set_debug_logging(bool is_debug);
+
 	// Functions.
 
 	void reserve_glasses(const StringName glasses_id, const String display_name);
@@ -153,12 +156,16 @@ protected:
 	GlassesIndexEntry *lookup_glasses_by_viewport(RID render_target);
 
 private:
+	void log_service_events();
+	void log_glasses_events();
+
 	bool _initialised = false;
 	XRServer *xr_server = nullptr;
 
 	String application_id;
 	String application_version;
 	float _trigger_click_threshold = 0.5;
+	bool _is_debug_logging = false;
 
 	std::vector<GlassesIndexEntry> _glasses_index;
 	std::vector<GlassesEvent> _glasses_events;


### PR DESCRIPTION
Add a Boolean project setting that will output debug logging when set. This is useful for collecting diagnostic information without turning on verbose mode in Godot and getting extraneous log messages. 