### PR TITLE
Implement glasses display name query

### DIFF
--- a/example.csharp/addons/tiltfive/T5Interface.cs
+++ b/example.csharp/addons/tiltfive/T5Interface.cs
@@ -116,7 +116,7 @@ public partial class T5Interface : Node
 			if(entry.Value.CanAttemptToReserve && Manager.ShouldUseGlasses(entry.Key))
 			{
 				entry.Value.attemptingToReserve = true;
-				xrInterface.Call("reserve_glasses", entry.Key, Manager.GetUIDisplayName(entry.Key));
+				xrInterface.Call("reserve_glasses", entry.Key, ProjectSettings.GetSetting("application/config/name"));
 			}
 		}
 	}

--- a/example.csharp/addons/tiltfive/T5Interface.cs
+++ b/example.csharp/addons/tiltfive/T5Interface.cs
@@ -89,6 +89,19 @@ public partial class T5Interface : Node
 		}
 	}
 
+	public string GetUIDisplayName(string glassesID)
+	{
+		if(string.IsNullOrEmpty(glassesID)
+			|| !xrInterface.Get("is_initialized").AsBool()
+			|| !glassesDictionary.TryGetValue(glassesID, out var xrRigState)
+			|| !xrRigState.available)
+		{
+			return string.Empty;
+		}
+
+		return xrInterface.Call("get_glasses_name", glassesID).AsString();
+	}
+
 	void StartDisplay(string glassesID, T5XRRig xrRig) {
 		
 		xrInterface.Call("start_display", glassesID, xrRig, xrRig.Origin);

--- a/example.csharp/addons/tiltfive/T5Manager.cs
+++ b/example.csharp/addons/tiltfive/T5Manager.cs
@@ -77,7 +77,10 @@ public partial class T5Manager : Node, T5ManagerInterface
 
 	public string GetUIDisplayName(string glassesID)
 	{
-		return T5ProjectSettings.DefaultDisplayName;
+		var uiDisplayName = t5Interface.GetUIDisplayName(glassesID);
+		return string.IsNullOrEmpty(uiDisplayName)
+			? T5ProjectSettings.DefaultDisplayName
+			: uiDisplayName;
 	}
 
 	public T5XRRig CreateXRRig(string glassesID)

--- a/extension/src/TiltFiveXRInterface.cpp
+++ b/extension/src/TiltFiveXRInterface.cpp
@@ -19,6 +19,7 @@ void TiltFiveXRInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("release_glasses", "glasses_id"), &TiltFiveXRInterface::release_glasses);
 	ClassDB::bind_method(D_METHOD("get_available_glasses_ids"), &TiltFiveXRInterface::get_available_glasses_ids);
 	ClassDB::bind_method(D_METHOD("get_reserved_glasses_ids"), &TiltFiveXRInterface::get_reserved_glasses_ids);
+	ClassDB::bind_method(D_METHOD("get_glasses_name", "glasses_id"), &TiltFiveXRInterface::get_glasses_name);
 	ClassDB::bind_method(D_METHOD("get_gameboard_type", "glasses_id"), &TiltFiveXRInterface::get_gameboard_type);
 	ClassDB::bind_method(D_METHOD("get_gameboard_extents", "gameboard_type"), &TiltFiveXRInterface::get_gameboard_extents);
 
@@ -282,6 +283,17 @@ PackedStringArray TiltFiveXRInterface::get_reserved_glasses_ids() {
 			reserved_list.append(glasses->get_id().c_str());
 	}
 	return reserved_list;
+}
+
+String TiltFiveXRInterface::get_glasses_name(const StringName glasses_id) {
+	if(!t5_service)
+		return String("");
+
+	auto entry = lookup_glasses_entry(glasses_id);
+	ERR_FAIL_COND_V_MSG(!entry, String(""), "Glasses id was not found");
+
+	std::string glasses_name = t5_service->get_glasses_name(entry->idx);
+	return String(glasses_name.c_str());
 }
 
 TiltFiveXRInterface::GameBoardType TiltFiveXRInterface::get_gameboard_type(const StringName glasses_id) {

--- a/extension/src/TiltFiveXRInterface.h
+++ b/extension/src/TiltFiveXRInterface.h
@@ -108,6 +108,8 @@ public:
 	PackedStringArray get_available_glasses_ids();
 	PackedStringArray get_reserved_glasses_ids();
 
+	String get_glasses_name(const StringName glasses_id);
+
 	// Overriden from XRInterfaceExtension
 	virtual StringName _get_name() const override;
 	virtual uint32_t _get_capabilities() const override;


### PR DESCRIPTION
Currently, getting the UI Display Name for a pair of Tilt Five glasses always returns the same string `T5ProjectSettings.DefaultDisplayName`.

This change exposes the native function required to retrieve the display name defined in the Tilt Five Control Panel, then revises the C# plugin to use it.

Additionally, this PR ensures that the application name is passed back to the Control Panel, rather than the glasses display name.