### PR TITLE
Update the Github CI asset assembly

### DIFF
--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -94,7 +94,7 @@ jobs:
   # This job collects the build output and assembles the final asset (artifact)
   asset:
     name: Assembling the asset (artifact)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: build
     permissions:
       contents: write


### PR DESCRIPTION
Need to update Ubuntu 20.04 because it was at the end of support