### PR TITLE
Refactors glasses connection handling.

### DIFF
--- a/extension/T5Integration/Logging.h
+++ b/extension/T5Integration/Logging.h
@@ -101,3 +101,19 @@ void log_message(T var1, Types... var2) {
 		}                                   \
 	}
 #endif
+
+struct __LogScope {
+	const char* function;
+	int line;
+	__LogScope(const char* func, int l) :
+			function(func), line(l) {
+		T5Integration::log_message("===> Entering ", function, " : ", line);
+	}
+	~__LogScope() {
+		T5Integration::log_message("<=== Leaving ", function, " : ", line);
+	}
+};
+
+#ifndef LOG_SCOPE
+#define LOG_SCOPE __LogScope __log_scope_instance##__LINE__(__func__, __LINE__);
+#endif

--- a/extension/T5Integration/StateFlags.h
+++ b/extension/T5Integration/StateFlags.h
@@ -69,6 +69,31 @@ public:
 		_current.store(from._current.load());
 	}
 
+	class ScopeGuard final {
+	public:
+		ScopeGuard(const ScopeGuard&) = delete;
+		ScopeGuard& operator=(const ScopeGuard&) = delete;
+		ScopeGuard(ScopeGuard&&) = delete;
+		ScopeGuard& operator=(ScopeGuard&&) = delete;
+
+		ScopeGuard(StateFlags<FlagType>& flags, FlagType state) :
+				_flags(flags), _state(state) {
+			_was_toggled = _flags.set_and_was_toggled(_state);
+		}
+		~ScopeGuard() {
+			if (_was_toggled)
+				_flags.clear(_state);
+		}
+		bool was_toggled() const {
+			return _was_toggled;
+		}
+
+	private:
+		StateFlags<FlagType>& _flags;
+		FlagType _state;
+		bool _was_toggled = false;
+	};
+
 private:
 	std::atomic<FlagType> _current;
 };

--- a/extension/src/OpenGLGlasses.cpp
+++ b/extension/src/OpenGLGlasses.cpp
@@ -61,11 +61,11 @@ void OpenGLGlasses::deallocate_textures() {
 	}
 }
 
-void OpenGLGlasses::on_start_display() {
+void OpenGLGlasses::on_allocate_render_textures() {
 	allocate_textures();
 }
 
-void OpenGLGlasses::on_stop_display() {
+void OpenGLGlasses::on_deallocate_render_textures() {
 	deallocate_textures();
 }
 

--- a/extension/src/OpenGLGlasses.h
+++ b/extension/src/OpenGLGlasses.h
@@ -28,8 +28,8 @@ private:
 	void allocate_textures();
 	void deallocate_textures();
 
-	virtual void on_start_display() override;
-	virtual void on_stop_display() override;
+	virtual void on_allocate_render_textures() override;
+	virtual void on_deallocate_render_textures() override;
 
 private:
 	std::vector<SwapChainTextures> _swap_chain_textures;

--- a/extension/src/TiltFiveXRInterface.cpp
+++ b/extension/src/TiltFiveXRInterface.cpp
@@ -223,7 +223,7 @@ void TiltFiveXRInterface::_start_display(TiltFiveXRInterface::GlassesIndexEntry&
 		WARN_PRINT("Glasses need to be reserved to display viewport");
 		return;
 	}
-	glasses->start_display();
+	glasses->alloc_render_textures();
 	entry.viewport_id = viewport->get_instance_id();
 	entry.gameboard_id = gameboard->get_instance_id();
 
@@ -244,7 +244,7 @@ void TiltFiveXRInterface::_stop_display(GlassesIndexEntry& entry) {
 		viewport->set_use_xr(false);
 		viewport->set_update_mode(godot::SubViewport::UpdateMode::UPDATE_DISABLED);
 	}
-	glasses->stop_display();
+	glasses->dealloc_render_textures();
 	entry.viewport_id = ObjectID();
 	entry.gameboard_id = ObjectID();
 }
@@ -286,7 +286,7 @@ PackedStringArray TiltFiveXRInterface::get_reserved_glasses_ids() {
 }
 
 String TiltFiveXRInterface::get_glasses_name(const StringName glasses_id) {
-	if(!t5_service)
+	if (!t5_service)
 		return String("");
 
 	auto entry = lookup_glasses_entry(glasses_id);
@@ -554,10 +554,9 @@ void TiltFiveXRInterface::_process() {
 		auto glasses_idx = _glasses_events[i].glasses_num;
 		switch (_glasses_events[i].event) {
 			case GlassesEvent::E_ADDED: {
-				if (_glasses_index.size() != glasses_idx) {
-					WARN_PRINT("Glasses index");
+				if (_glasses_index.size() <= glasses_idx) {
+					_glasses_index.resize(glasses_idx + 1);
 				}
-				_glasses_index.resize(glasses_idx + 1);
 				auto glasses = t5_service->get_glasses(glasses_idx);
 				glasses->set_trigger_click_threshold(_trigger_click_threshold);
 

--- a/extension/src/VulkanGlasses.cpp
+++ b/extension/src/VulkanGlasses.cpp
@@ -103,11 +103,11 @@ void VulkanGlasses::deallocate_textures() {
 	}
 }
 
-void VulkanGlasses::on_start_display() {
+void VulkanGlasses::on_allocate_render_textures() {
 	allocate_textures();
 }
 
-void VulkanGlasses::on_stop_display() {
+void VulkanGlasses::on_deallocate_render_textures() {
 	deallocate_textures();
 }
 

--- a/extension/src/VulkanGlasses.h
+++ b/extension/src/VulkanGlasses.h
@@ -29,8 +29,8 @@ private:
 	void allocate_textures();
 	void deallocate_textures();
 
-	virtual void on_start_display() override;
-	virtual void on_stop_display() override;
+	virtual void on_allocate_render_textures() override;
+	virtual void on_deallocate_render_textures() override;
 
 private:
 	std::vector<SwapChainTextures> _swap_chain_textures;


### PR DESCRIPTION
Improves glasses connection and disconnection logic to handle unavailable glasses more robustly.

Renames `on_start_display` and `on_stop_display` to `on_allocate_render_textures` and `on_deallocate_render_textures` respectively to better reflect their purpose.

Adds a monitor task for unavailable glasses and logic to re-attempt connection.

Adds the `set_existing` API to the Glasses class to separate glasses handle creation from the state of being existing member of the NDK glasses list.